### PR TITLE
Fix Service filtration

### DIFF
--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -68,7 +68,7 @@ func FilterPodsForController(controllerName string, controllerType string, allPo
 func FilterServicesForSelector(selector labels.Selector, allServices []core_v1.Service) []core_v1.Service {
 	var services []core_v1.Service
 	for _, svc := range allServices {
-		if selector.Matches(labels.Set(svc.Spec.Selector)) {
+		if selector.Matches(labels.Set(svc.Spec.Selector)) || selector.Matches(labels.Set(svc.ObjectMeta.Labels)) {
 			services = append(services, svc)
 		}
 	}


### PR DESCRIPTION
Service filtration is now based on "selectors vs labels", and not "selectors vs selectors"

** Describe the change **

Service filtration is now based on "selectors vs labels", and not "selectors vs selectors"

** Issue reference **

3656

** Backwards incompatible? **

No

