### PR TITLE
Dedup function fetchNamespaceApps for single app case

### DIFF
--- a/business/health.go
+++ b/business/health.go
@@ -114,7 +114,7 @@ func (in *HealthService) GetNamespaceAppHealth(namespace, rateInterval string, q
 	promtimer := internalmetrics.GetGoFunctionMetric("business", "HealthService", "GetNamespaceAppHealth")
 	defer promtimer.ObserveNow(&err)
 
-	appEntities, err := fetchNamespaceApps(in.businessLayer, namespace, "")
+	appEntities, err := fetchNamespaceApps(in.businessLayer, namespace)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
There was several conditional checks for single app case, and
non optimal reasoning with 'castAppDetails' with useless map usage in that
case. Deduplicating for seperation of concerns.

It also allows to bypass a second service filtering based on selector for apps